### PR TITLE
chore: update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -154,6 +154,7 @@ IntegerLiteralSeparator:
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+# KeepEmptyLinesAtEOF: false
 KeepEmptyLinesAtEOF: true
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF

--- a/.clang-format
+++ b/.clang-format
@@ -154,7 +154,7 @@ IntegerLiteralSeparator:
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-KeepEmptyLinesAtEOF: false
+KeepEmptyLinesAtEOF: true
 LambdaBodyIndentation: Signature
 LineEnding:      DeriveLF
 MacroBlockBegin: ''

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: super-linter/super-linter/slim@v7.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: ./
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CLANG_FORMAT: true
           VALIDATE_GITHUB_ACTIONS: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: ./
           VALIDATE_ALL_CODEBASE: false
-          VALIDATE_CLANG_FORMAT: true
           VALIDATE_GITHUB_ACTIONS: true
           GITHUB_ACTIONS_COMMAND_ARGS: -ignore 'label "windows-2025" is unknown'
           VALIDATE_GITLEAKS: true

--- a/include/nou/detail/network/network.hpp
+++ b/include/nou/detail/network/network.hpp
@@ -1,1 +1,2 @@
 #pragma once
+

--- a/include/nou/nou.hpp
+++ b/include/nou/nou.hpp
@@ -1,3 +1,4 @@
 #pragma once
 
 #include "nou/detail/network/network.hpp"
+

--- a/test/ut/network.cc
+++ b/test/ut/network.cc
@@ -3,3 +3,4 @@
 #include "boost/ut.hpp"
 
 auto main() -> int { return 0; }
+


### PR DESCRIPTION
update .clang-format to keep empty lines at EOF
