### PR TITLE
Feature/network construction

### DIFF
--- a/include/nou/detail/layer/builder.hpp
+++ b/include/nou/detail/layer/builder.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "nou/detail/layer/layer.hpp"
+
+namespace nou {
+
+template <class T, class Extents>
+concept builder = requires(T builder, Extents extents) {
+  { builder.build(extents) } -> layer;
+};
+
+}  // namespace nou
+

--- a/include/nou/detail/layer/is_connectable.hpp
+++ b/include/nou/detail/layer/is_connectable.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+
+#include "nou/detail/layer/layer.hpp"
+
+namespace nou {
+
+template <class... Ts>
+struct is_connectable : std::false_type {};
+
+template <layer T>
+struct is_connectable<T> : std::true_type {};
+
+template <layer T, layer U>
+  requires std::same_as<typename T::output_extents_type,
+                        typename U::input_extents_type>
+struct is_connectable<T, U> : std::true_type {};
+
+template <layer T, layer U, layer... Ts>
+  requires std::same_as<typename T::output_extents_type,
+                        typename U::input_extents_type>
+struct is_connectable<T, U, Ts...> : is_connectable<U, Ts...> {};
+
+template <class... Ts>
+constexpr auto is_connectable_v = is_connectable<Ts...>::value;
+
+}  // namespace nou
+

--- a/include/nou/detail/layer/layer.hpp
+++ b/include/nou/detail/layer/layer.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace nou {
+
+template <class T>
+concept layer = requires(T layer) {
+  typename T::input_extents_type;
+  typename T::output_extents_type;
+};
+
+}  // namespace nou
+

--- a/include/nou/detail/layer/layer.hpp
+++ b/include/nou/detail/layer/layer.hpp
@@ -1,11 +1,16 @@
 #pragma once
 
+#include <concepts>
+
 namespace nou {
 
 template <class T>
 concept layer = requires(T layer) {
   typename T::input_extents_type;
   typename T::output_extents_type;
+
+  { layer.input_extents() } -> std::same_as<typename T::input_extents_type>;
+  { layer.output_extents() } -> std::same_as<typename T::output_extents_type>;
 };
 
 }  // namespace nou

--- a/include/nou/detail/network/make_network.hpp
+++ b/include/nou/detail/network/make_network.hpp
@@ -10,12 +10,12 @@
 namespace nou {
 
 template <layer Layer>
-constexpr auto make_network(Layer&& layer) -> decltype(auto) {
+[[nodiscard]] constexpr auto make_network(Layer&& layer) noexcept {
   return network{std::forward<Layer>(layer)};
 }
 
 template <layer Layer, class... Ts>
-constexpr auto make_network(Layer&& first, Ts&&... trailing) -> decltype(auto) {
+[[nodiscard]] constexpr auto make_network(Layer&& first, Ts&&... trailing) {
   return []<class Self, class Layers, class T, class... Us>(
              this Self&& self, Layers&& layers, T&& target, Us&&... trailing)
     requires layer<decltype(auto(target))> ||

--- a/include/nou/detail/network/make_network.hpp
+++ b/include/nou/detail/network/make_network.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <tuple>
+#include <utility>
+
+#include "nou/detail/layer/builder.hpp"
+#include "nou/detail/layer/layer.hpp"
+#include "nou/detail/network/network.hpp"
+
+namespace nou {
+
+template <layer Layer>
+constexpr auto make_network(Layer&& layer) -> decltype(auto) {
+  return network{std::forward<Layer>(layer)};
+}
+
+template <layer Layer, class... Ts>
+constexpr auto make_network(Layer&& first, Ts&&... trailing) -> decltype(auto) {
+  return []<class Self, class Layers, class T, class... Us>(
+             this Self&& self, Layers&& layers, T&& target, Us&&... trailing)
+    requires layer<decltype(auto(target))> ||
+             builder<decltype(auto(target)),
+                     typename decltype(auto(
+                         std::get<std::tuple_size_v<Layers> - 1>(
+                             layers)))::output_extents_type>
+  {
+    auto concat = [](auto&& layers, auto&& target) {
+      if constexpr (::nou::layer<decltype(auto(target))>) {
+        return std::tuple_cat(std::forward<Layers>(layers),
+                              std::tuple{std::forward<T>(target)});
+      } else {
+        auto layer = std::forward<T>(target).build(
+            std::get<std::tuple_size_v<Layers> - 1>(layers).output_extents());
+        return std::tuple_cat(std::forward<Layers>(layers),
+                              std::tuple{std::move(layer)});
+      }
+    }(std::forward<Layers>(layers), std::forward<T>(target));
+
+    if constexpr (sizeof...(Us) == 0) {
+      return std::apply(
+          []<class... Vs>(Vs&&... layers) noexcept {
+            return network{std::forward<Vs>(layers)...};
+          },
+          std::move(concat));
+    } else {
+      return std::forward<Self>(self)(std::move(concat),
+                                      std::forward<Us>(trailing)...);
+    }
+  }(std::make_tuple(std::forward<Layer>(first)), std::forward<Ts>(trailing)...);
+}
+
+}  // namespace nou
+

--- a/include/nou/detail/network/make_network.hpp
+++ b/include/nou/detail/network/make_network.hpp
@@ -20,12 +20,11 @@ template <layer Layer, class... Ts>
              this Self&& self, Layers&& layers, T&& target, Us&&... trailing)
     requires layer<decltype(auto(target))> ||
              builder<decltype(auto(target)),
-                     typename decltype(auto(
-                         std::get<std::tuple_size_v<Layers> - 1>(
-                             layers)))::output_extents_type>
+                     decltype(std::get<std::tuple_size_v<Layers> - 1>(layers)
+                                  .output_extents())>
   {
     auto concat = [](auto&& layers, auto&& target) {
-      if constexpr (::nou::layer<decltype(auto(target))>) {
+      if constexpr (layer<decltype(auto(target))>) {
         return std::tuple_cat(std::forward<Layers>(layers),
                               std::tuple{std::forward<T>(target)});
       } else {

--- a/include/nou/detail/network/network.hpp
+++ b/include/nou/detail/network/network.hpp
@@ -1,2 +1,44 @@
 #pragma once
 
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "nou/detail/layer/is_connectable.hpp"
+#include "nou/detail/layer/layer.hpp"
+
+namespace nou {
+
+template <layer... Layers>
+  requires is_connectable_v<Layers...>
+class network {
+ public:
+  // Constructors
+  network() = default;
+
+  template <class... Ts>
+  explicit constexpr network(Ts&&... layers) noexcept
+      : layers_{std::make_tuple(std::forward<Ts>(layers)...)} {}
+
+  // Operator overloads
+  template <class... Ts>
+    requires(std::equality_comparable<Layers> && ...)
+  [[nodiscard]] constexpr auto operator==(const network<Ts...>& rhs) const
+      noexcept(noexcept(layers_ == rhs.layers_)) -> bool {
+    return layers_ == rhs.layers_;
+  }
+
+ private:
+  // Type aliases
+  using layers_type = std::tuple<Layers...>;
+
+  // Member variables
+  layers_type layers_;
+};
+
+template <class... Ts>
+network(Ts&&...) -> network<std::remove_cvref_t<Ts>...>;
+
+}  // namespace nou
+

--- a/include/nou/detail/network/network.hpp
+++ b/include/nou/detail/network/network.hpp
@@ -12,13 +12,13 @@ namespace nou {
 
 template <layer... Layers>
   requires is_connectable_v<Layers...>
-class network {
+class network final {
  public:
   // Constructors
   network() = default;
 
   template <class... Ts>
-  explicit constexpr network(Ts&&... layers) noexcept
+  [[nodiscard]] explicit constexpr network(Ts&&... layers) noexcept
       : layers_{std::make_tuple(std::forward<Ts>(layers)...)} {}
 
   // Operator overloads

--- a/include/nou/detail/utility/extents.hpp
+++ b/include/nou/detail/utility/extents.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <concepts>
 #include <cstddef>
+#include <optional>
 #include <tuple>
 
 namespace nou {
@@ -20,7 +21,11 @@ class extents final {
   static constexpr auto rank() noexcept -> rank_type { return sizeof...(Ns); }
 
   // Member functions
-  static constexpr auto static_extent(rank_type rank) noexcept -> size_type {
+  static constexpr auto static_extent(rank_type rank) noexcept
+      -> std::optional<size_type> {
+    if (rank >= extents<T, Ns...>::rank()) {
+      return std::nullopt;
+    }
     static constexpr std::array extents_{Ns...};
     return extents_[rank];
   }

--- a/include/nou/detail/utility/extents.hpp
+++ b/include/nou/detail/utility/extents.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <tuple>
+
+namespace nou {
+
+template <class T, std::unsigned_integral auto... Ns>
+  requires(sizeof...(Ns) > 0)
+class extents final {
+ public:
+  // Type aliases
+  using element_type = T;
+  using rank_type = std::size_t;
+  using size_type = std::tuple_element_t<0, std::tuple<decltype(Ns)...>>;
+
+  // Static Member functions
+  static constexpr auto rank() noexcept -> rank_type { return sizeof...(Ns); }
+
+  // Member functions
+  static constexpr auto static_extent(rank_type rank) noexcept -> size_type {
+    static constexpr std::array extents_{Ns...};
+    return extents_[rank];
+  }
+};
+
+}  // namespace nou
+

--- a/include/nou/nou.hpp
+++ b/include/nou/nou.hpp
@@ -1,4 +1,5 @@
 #pragma once
 
+#include "nou/detail/network/make_network.hpp"
 #include "nou/detail/network/network.hpp"
 

--- a/test/ut/is_connectable.cc
+++ b/test/ut/is_connectable.cc
@@ -1,0 +1,47 @@
+#include "nou/detail/layer/is_connectable.hpp"
+
+#include <boost/ut.hpp>
+#include <concepts>
+
+#include "nou/detail/utility/extents.hpp"
+
+namespace mock {
+
+template <std::unsigned_integral auto Input, std::unsigned_integral auto Output>
+struct layer {
+  using input_extents_type = nou::extents<float, Input>;
+  using output_extents_type = nou::extents<float, Output>;
+};
+
+}  // namespace mock
+
+auto main() -> int {
+  using namespace boost::ut;
+
+  "one layer should be connectable"_test = [] {
+    static_assert(nou::is_connectable_v<mock::layer<1UZ, 1UZ>>);
+  };
+
+  "two layers with matching extents should be connectable"_test = [] {
+    static_assert(
+        nou::is_connectable_v<mock::layer<1UZ, 2UZ>, mock::layer<2UZ, 3UZ>>);
+  };
+
+  "two layers with non-matching extents should not be connectable"_test = [] {
+    static_assert(not nou::is_connectable_v<mock::layer<1UZ, 2UZ>,
+                                            mock::layer<3UZ, 4UZ>>);
+  };
+
+  "three layers with matching extents should be connectable"_test = [] {
+    static_assert(
+        nou::is_connectable_v<mock::layer<1UZ, 2UZ>, mock::layer<2UZ, 3UZ>,
+                              mock::layer<3UZ, 4UZ>>);
+  };
+
+  "three layers with non-matching extents should not be connectable"_test = [] {
+    static_assert(
+        not nou::is_connectable_v<mock::layer<1UZ, 2UZ>, mock::layer<2UZ, 3UZ>,
+                                  mock::layer<4UZ, 3UZ>>);
+  };
+}
+

--- a/test/ut/is_connectable.cc
+++ b/test/ut/is_connectable.cc
@@ -1,8 +1,8 @@
 #include "nou/detail/layer/is_connectable.hpp"
 
-#include <boost/ut.hpp>
 #include <concepts>
 
+#include "boost/ut.hpp"
 #include "nou/detail/utility/extents.hpp"
 
 namespace mock {

--- a/test/ut/is_connectable.cc
+++ b/test/ut/is_connectable.cc
@@ -11,6 +11,15 @@ template <std::unsigned_integral auto Input, std::unsigned_integral auto Output>
 struct layer {
   using input_extents_type = nou::extents<float, Input>;
   using output_extents_type = nou::extents<float, Output>;
+
+  [[nodiscard]] constexpr auto input_extents() const noexcept
+      -> input_extents_type {
+    return {};
+  }
+  [[nodiscard]] constexpr auto output_extents() const noexcept
+      -> output_extents_type {
+    return {};
+  }
 };
 
 }  // namespace mock

--- a/test/ut/make_network.cc
+++ b/test/ut/make_network.cc
@@ -1,0 +1,133 @@
+#include "nou/detail/network/make_network.hpp"
+
+#include <concepts>
+
+#include "boost/ut.hpp"
+#include "nou/detail/layer/layer.hpp"
+#include "nou/detail/network/network.hpp"
+#include "nou/detail/utility/extents.hpp"
+
+namespace mock {
+
+template <std::unsigned_integral auto Input, std::unsigned_integral auto Output>
+struct layer {
+  using input_extents_type = nou::extents<float, Input>;
+  using output_extents_type = nou::extents<float, Output>;
+
+  [[nodiscard]] constexpr auto input_extents() const noexcept
+      -> input_extents_type {
+    return {};
+  }
+  [[nodiscard]] constexpr auto output_extents() const noexcept
+      -> output_extents_type {
+    return {};
+  }
+};
+
+template <std::unsigned_integral auto... Ns>
+[[nodiscard]] constexpr auto operator==(const layer<Ns...>&,
+                                        const layer<Ns...>&) -> bool {
+  return true;
+}
+
+template <std::unsigned_integral auto Output>
+struct builder {
+  using output_extents_type = nou::extents<float, Output>;
+
+  template <class T, std::unsigned_integral auto Input>
+  [[nodiscard]] constexpr auto build(
+      const nou::extents<T, Input>&) const noexcept -> layer<Input, Output> {
+    return {};
+  }
+};
+
+}  // namespace mock
+
+auto main() -> int {
+  using namespace boost::ut;
+
+  "make network from one layer"_test = [] {
+    using layer = mock::layer<1UZ, 2UZ>;
+    static_assert(nou::layer<layer>);
+
+    constexpr auto network = nou::make_network(layer{});
+
+    static_assert(std::same_as<decltype(auto(network)), nou::network<layer>>);
+    static_assert(network == nou::network{layer{}});
+  };
+
+  "make network from two layers"_test = [] {
+    using layer1 = mock::layer<1UZ, 2UZ>;
+    using layer2 = mock::layer<2UZ, 3UZ>;
+    static_assert(nou::layer<layer1> && nou::layer<layer2>);
+
+    constexpr auto network = nou::make_network(layer1{}, layer2{});
+
+    static_assert(
+        std::same_as<decltype(auto(network)), nou::network<layer1, layer2>>);
+    static_assert(network == nou::network{layer1{}, layer2{}});
+  };
+
+  "make network from three layers"_test = [] {
+    using layer1 = mock::layer<1UZ, 2UZ>;
+    using layer2 = mock::layer<2UZ, 3UZ>;
+    using layer3 = mock::layer<3UZ, 4UZ>;
+    static_assert(nou::layer<layer1> && nou::layer<layer2> &&
+                  nou::layer<layer3>);
+
+    constexpr auto network = nou::make_network(layer1{}, layer2{}, layer3{});
+
+    static_assert(std::same_as<decltype(auto(network)),
+                               nou::network<layer1, layer2, layer3>>);
+    static_assert(network == nou::network{layer1{}, layer2{}, layer3{}});
+  };
+
+  "make network from one layer and one builder"_test = [] {
+    using layer = mock::layer<1UZ, 2UZ>;
+    using builder = mock::builder<3UZ>;
+    static_assert(nou::layer<layer> &&
+                  nou::builder<builder, typename layer::output_extents_type>);
+
+    constexpr auto network = nou::make_network(layer{}, builder{});
+
+    static_assert(std::same_as<decltype(auto(network)),
+                               nou::network<layer, mock::layer<2UZ, 3UZ>>>);
+    static_assert(network == nou::network{layer{}, mock::layer<2UZ, 3UZ>{}});
+  };
+
+  "make network from [layer -> builder -> layer]"_test = [] {
+    using layer1 = mock::layer<1UZ, 2UZ>;
+    using builder = mock::builder<3UZ>;
+    using layer2 = mock::layer<3UZ, 4UZ>;
+    static_assert(nou::layer<layer1> && nou::layer<layer2> &&
+                  nou::builder<builder, typename layer1::output_extents_type>);
+
+    constexpr auto network = nou::make_network(layer1{}, builder{}, layer2{});
+
+    static_assert(
+        std::same_as<decltype(auto(network)),
+                     nou::network<layer1, mock::layer<2UZ, 3UZ>, layer2>>);
+    static_assert(network ==
+                  nou::network{layer1{}, mock::layer<2UZ, 3UZ>{}, layer2{}});
+  };
+
+  "make network from [layer -> builder -> builder]"_test = [] {
+    using layer1 = mock::layer<1UZ, 2UZ>;
+    using builder1 = mock::builder<3UZ>;
+    using builder2 = mock::builder<4UZ>;
+    static_assert(
+        nou::layer<layer1> &&
+        nou::builder<builder1, typename layer1::output_extents_type> &&
+        nou::builder<builder2, typename builder1::output_extents_type>);
+
+    constexpr auto network =
+        nou::make_network(layer1{}, builder1{}, builder2{});
+
+    static_assert(std::same_as<decltype(auto(network)),
+                               nou::network<layer1, mock::layer<2UZ, 3UZ>,
+                                            mock::layer<3UZ, 4UZ>>>);
+    static_assert(network == nou::network{layer1{}, mock::layer<2UZ, 3UZ>{},
+                                          mock::layer<3UZ, 4UZ>{}});
+  };
+}
+

--- a/test/ut/meson.build
+++ b/test/ut/meson.build
@@ -1,6 +1,7 @@
 unit_tests = [
   'network',
   'is_connectable',
+  'make_network',
 ]
 
 foreach name: unit_tests

--- a/test/ut/meson.build
+++ b/test/ut/meson.build
@@ -1,5 +1,6 @@
 unit_tests = [
-  'network'
+  'network',
+  'is_connectable',
 ]
 
 foreach name: unit_tests

--- a/test/ut/meson.build
+++ b/test/ut/meson.build
@@ -4,6 +4,8 @@ unit_tests = [
   'make_network',
 ]
 
+nomalloc = environment({'MALLOC_PERTURB_': '0'})
+
 foreach name: unit_tests
   test(
     'ut_' + name,
@@ -12,7 +14,8 @@ foreach name: unit_tests
       name + '.cc',
       include_directories: inc_dirs,
       dependencies: [test_dep],
-    )
+    ),
+    env: nomalloc,
   )
 endforeach
 

--- a/test/ut/meson.build
+++ b/test/ut/meson.build
@@ -4,8 +4,6 @@ unit_tests = [
   'make_network',
 ]
 
-nomalloc = environment({'MALLOC_PERTURB_': '0'})
-
 foreach name: unit_tests
   test(
     'ut_' + name,
@@ -14,8 +12,7 @@ foreach name: unit_tests
       name + '.cc',
       include_directories: inc_dirs,
       dependencies: [test_dep],
-    ),
-    env: nomalloc,
+    )
   )
 endforeach
 

--- a/test/ut/network.cc
+++ b/test/ut/network.cc
@@ -1,6 +1,57 @@
 #include "nou/detail/network/network.hpp"
 
-#include "boost/ut.hpp"
+#include <concepts>
 
-auto main() -> int { return 0; }
+#include "boost/ut.hpp"
+#include "nou/detail/utility/extents.hpp"
+
+namespace mock {
+
+template <std::unsigned_integral auto Input, std::unsigned_integral auto Output>
+struct layer {
+  using input_extents_type = nou::extents<float, Input>;
+  using output_extents_type = nou::extents<float, Output>;
+};
+
+template <std::unsigned_integral auto... Ns>
+constexpr auto operator==(const layer<Ns...>&, const layer<Ns...>&) -> bool {
+  return true;
+}
+
+}  // namespace mock
+
+auto main() -> int {
+  using namespace boost::ut;
+
+  "concepts"_test = [] {
+    using layer1 = mock::layer<1UZ, 2UZ>;
+    using layer2 = mock::layer<2UZ, 3UZ>;
+    using network = nou::network<layer1, layer2>;
+
+    static_assert(std::regular<network>);
+    static_assert(std::constructible_from<network, layer1, layer2>);
+    static_assert(std::constructible_from<network, layer1&, layer2&>);
+    static_assert(
+        std::constructible_from<network, const layer1&, const layer2&>);
+    static_assert(std::constructible_from<network, layer1&&, layer2&&>);
+  };
+
+  [[maybe_unused]] suite constructor = [] {
+    "network should be constructed with one layer"_test = [] {
+      using layer_t = mock::layer<1UZ, 1UZ>;
+      static_assert(nou::network<layer_t>{} == nou::network{layer_t{}});
+    };
+
+    "network should be constructed with connectable layers"_test = [] {
+      using layer1_t = mock::layer<1UZ, 2UZ>;
+      using layer2_t = mock::layer<2UZ, 3UZ>;
+      static_assert(nou::is_connectable_v<layer1_t, layer2_t>);
+
+      static_assert(nou::network<layer1_t, layer2_t>{} ==
+                    nou::network{layer1_t{}, layer2_t{}});
+    };
+  };
+
+  return 0;
+}
 

--- a/test/ut/network.cc
+++ b/test/ut/network.cc
@@ -23,7 +23,8 @@ struct layer {
 };
 
 template <std::unsigned_integral auto... Ns>
-constexpr auto operator==(const layer<Ns...>&, const layer<Ns...>&) -> bool {
+[[nodiscard]] constexpr auto operator==(const layer<Ns...>&,
+                                        const layer<Ns...>&) noexcept -> bool {
   return true;
 }
 

--- a/test/ut/network.cc
+++ b/test/ut/network.cc
@@ -11,6 +11,15 @@ template <std::unsigned_integral auto Input, std::unsigned_integral auto Output>
 struct layer {
   using input_extents_type = nou::extents<float, Input>;
   using output_extents_type = nou::extents<float, Output>;
+
+  [[nodiscard]] constexpr auto input_extents() const noexcept
+      -> input_extents_type {
+    return {};
+  }
+  [[nodiscard]] constexpr auto output_extents() const noexcept
+      -> output_extents_type {
+    return {};
+  }
 };
 
 template <std::unsigned_integral auto... Ns>


### PR DESCRIPTION
This pull request introduces a new set of utilities for handling network layers and their connections in the `nou` namespace. The changes include the addition of new concepts, structures, and tests to ensure the functionality of these utilities. The most important changes are summarized below:

### New Concepts and Structures:

* [`include/nou/detail/layer/layer.hpp`](diffhunk://#diff-259828656296294931536c60c5d35b828b2ff920a43268e181e7178afa326839R1-R17): Introduced the `layer` concept to define the requirements for a type to be considered a layer.
* [`include/nou/detail/layer/builder.hpp`](diffhunk://#diff-2318d065bd11f8dca3693143a7b70a8d879831fac99fd48235cf6f5a1454475aR1-R13): Added the `builder` concept to specify the requirements for a builder type that can construct layers.
* [`include/nou/detail/layer/is_connectable.hpp`](diffhunk://#diff-19eafc09254c2ce5da3d330580c9cbbc73a63b1b409869158129b556390376eaR1-R30): Created the `is_connectable` structure to determine if layers can be connected based on their input and output extents.
* [`include/nou/detail/network/network.hpp`](diffhunk://#diff-cddfa532c94d1c6f67fe426aecfa4e823b0d1d5c6e0ca29f22d60a58664b651dR3-R44): Defined the `network` class template to represent a network of connected layers, ensuring that the layers are connectable.
* [`include/nou/detail/network/make_network.hpp`](diffhunk://#diff-72176e8da9223d57c4c18c5cf80976a657212de8564b602f19dd62118c005aceR1-R52): Implemented the `make_network` function template to create a network from a sequence of layers and builders.

### Utility and Extents:

* [`include/nou/detail/utility/extents.hpp`](diffhunk://#diff-aefe1a53fada6aa61cb2359593e36e0bbee28998af02067e3354829385edf6c2R1-R35): Added the `extents` class template to represent the dimensions of a layer's input or output.

### Tests:

* [`test/ut/is_connectable.cc`](diffhunk://#diff-5df83bdadafc3bcb7c68c8c41603730d193df1339043eb1fb64ed1eabba6f32cR1-R56): Added unit tests for the `is_connectable` structure to verify the connectivity of various layer configurations.
* [`test/ut/make_network.cc`](diffhunk://#diff-08775d0a2ab3bd564dde4607020a665f29f6b6bc763ba63a120c2824e5edd73cR1-R133): Added unit tests for the `make_network` function to ensure correct network creation from layers and builders.
* [`test/ut/network.cc`](diffhunk://#diff-a11143319754f21fc4f36e3e2899e1d74596a5148a64d4205755e716cf4763ddR3-R66): Expanded the unit tests for the `network` class to validate its construction and concept requirements.
* [`test/ut/meson.build`](diffhunk://#diff-1c931d4d83ffb38cbf23b9e2f2e278ca79bc6d9db994c2a9c4ede46486dd3255L2-R4): Updated the build configuration to include the new unit tests for `is_connectable` and `make_network`.

These changes collectively enhance the `nou` namespace by providing robust tools for defining, building, and connecting network layers, along with comprehensive tests to ensure their correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced advanced network and layer management capabilities.
  - Added support for creating networks with multiple layers.
  - Implemented type-safe layer connectivity checks.
  - Added new concepts for `builder`, `layer`, and `is_connectable` to enhance type safety.
  - Introduced a new class `network` for managing connectable layers.
  - Added a new template class `extents` for multi-dimensional extents representation.

- **Improvements**
  - Enhanced type constraints for network and layer construction.
  - Added compile-time validation for layer connections.
  - Introduced a flexible template function `make_network` for network creation.

- **Testing**
  - Expanded unit test coverage for network and layer functionality.
  - Added comprehensive tests for network creation and layer connectivity.
  - Introduced new tests for `is_connectable` and `make_network`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->